### PR TITLE
Use GRAPH_VIDEO const for graph-video endpoint

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -24,6 +24,9 @@ export default class FacebookAdsApi {
   static get GRAPH () {
     return 'https://graph.facebook.com';
   }
+  static get GRAPH_VIDEO () {
+    return 'https://graph-video.facebook.com';
+  }
 
   /**
    * @param {String} accessToken

--- a/src/video-uploader.js
+++ b/src/video-uploader.js
@@ -385,7 +385,7 @@ class VideoUploadRequest {
           this._params,
           this._files,
           true, // use multipart/form-data
-          'https://graph-video.facebook.com' // override graph.facebook.com
+          FacebookAdsApi.GRAPH_VIDEO // override graph.facebook.com
         )
         .then(response => resolve(JSON.parse(response)))
         .catch(error => reject(error));


### PR DESCRIPTION
It wasn't clear to me the `graph-video` URL was being used, which caused some headaches in debugging. It would be great to get this merged in so we can just use the `FacebookAdsApi` class as a reference