### PR TITLE
Update API version to v2.10

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -19,7 +19,7 @@ export default class FacebookAdsApi {
   locale: string;
   static _defaultApi: FacebookAdsApi;
   static get VERSION () {
-    return 'v2.9';
+    return 'v2.10';
   }
   static get GRAPH () {
     return 'https://graph.facebook.com';


### PR DESCRIPTION
I got a deprecation warning today stating `v2.9` won't be available after November 6th, 2017. I went ahead and updated to `v2.10`. I checked the change log and didn't see any breaking changes for this: https://developers.facebook.com/docs/graph-api/changelog/breaking-changes

![image](https://user-images.githubusercontent.com/3393723/32507839-90465494-c3b6-11e7-8210-6ad880ebd6a2.png)
