### PR TITLE
Fix equality testing

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -51,7 +51,7 @@ export default class Http {
         try {
           const response = JSON.parse(request.response);
 
-          if (request.status == HTTP_STATUS.OK) {
+          if (request.status.toString() === HTTP_STATUS.OK) {
             resolve(response);
           } else {
             reject(


### PR DESCRIPTION
Cast request.status to string and compare with === to prevent unexpected bugs in the future.

Note: Retain constants in HTTP_STATUS as string because they are used to compare with other string response code.